### PR TITLE
Updates and small fixes

### DIFF
--- a/deploy/1.17/csi-controller.yaml
+++ b/deploy/1.17/csi-controller.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: csi-controller
       containers:
       - name: csi-provisioner
-        image: quay.io/k8scsi/csi-provisioner:v1.5.0
+        image: quay.io/k8scsi/csi-provisioner:v1.6.0
         args:
         - "--v=5"
         - "--csi-address=/csi/csi.sock"
@@ -30,7 +30,7 @@ spec:
           - name: socket-dir
             mountPath: /csi
       - name: csi-attacher
-        image: quay.io/k8scsi/csi-attacher:v2.1.0
+        image: quay.io/k8scsi/csi-attacher:v2.2.0
         args:
         - "--v=5"
         - "--csi-address=/csi/csi.sock"
@@ -47,7 +47,7 @@ spec:
           - name: socket-dir
             mountPath: /csi
       - name: csi-snapshotter
-        image: quay.io/k8scsi/csi-snapshotter:v2.0.0
+        image: quay.io/k8scsi/csi-snapshotter:v2.1.1
         args:
         - "--v=5"
         - "--csi-address=/csi/csi.sock"
@@ -55,7 +55,7 @@ spec:
           - name: socket-dir
             mountPath: /csi
       - name: csi-controller
-        image: flant/yandex-csi-plugin:v0.9.6
+        image: flant/yandex-csi-plugin:v0.9.7
         args:
         - "--address=$(MY_POD_IP):12302"
         - "--endpoint=unix:/csi/csi.sock"

--- a/deploy/1.17/csi-node.yaml
+++ b/deploy/1.17/csi-node.yaml
@@ -24,10 +24,6 @@ spec:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
             - "--kubelet-registration-path=/var/lib/kubelet/plugins/yandex.csi.flant.com/csi.sock"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/yandex.csi.flant.com-reg.sock /csi/csi.sock"]
           env:
             - name: KUBE_NODE_NAME
               valueFrom:

--- a/deploy/1.17/csi-node.yaml
+++ b/deploy/1.17/csi-node.yaml
@@ -19,7 +19,7 @@ spec:
         - operator: Exists
       containers:
         - name: csi-node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -41,7 +41,7 @@ spec:
         - name: csi-node
           securityContext:
             privileged: true
-          image: flant/yandex-csi-plugin:v0.9.6
+          image: flant/yandex-csi-plugin:v0.9.7
           args:
             - "--endpoint=unix:/csi/csi.sock"
           volumeMounts:


### PR DESCRIPTION
hello. thnx for awesome work. not so hard but tested with:
1. k8s 1.18.2 with docker and calico
2. k8s 1.18.2 with cri-o and kube-router
no issues detected. just works :heart_eyes_cat:. small updates:
- core images
- lifecycle statement: csi-node-driver-registrar use distroless base, https://github.com/kubernetes-csi/node-driver-registrar/issues/21