### PR TITLE
Fix XFS resize never completing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN apk add --no-cache ca-certificates \
                        e2fsprogs \
                        findmnt \
                        xfsprogs \
+                       xfsprogs-extra \
                        blkid \
                        e2fsprogs-extra
 


### PR DESCRIPTION
Expanding XFS volumes never completes as there is no `xfs_growfs` binary in the container. This PR updates Dockerfile to include the `xfsprogs-extra` package providing it.

In case anyone needs this before it's merged:
```
ghcr.io/icekom/yandex-csi-driver@sha256:662f552a3c3f61185942f75c6a3b7f42c22067fefe3133c219cc33398617d81d
```
[(link)](https://github.com/icekom/yandex-csi-driver/pkgs/container/yandex-csi-driver/40355364)